### PR TITLE
Target es5

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,13 +21,9 @@
     "brace-style": [2, "stroustrup", {"allowSingleLine": true}],
     "handle-callback-err": [2, "^(e|err|error)$" ],
     "one-var": [2, "never"],
-    "no-unexpected-multiline": 2,
-    "no-const-assign": 2,
-    "prefer-const": 2,
-    "no-var": 2
+    "no-unexpected-multiline": 2
   },
   "env": {
-    "es6": true,
     "node": true,
     "browser": true,
     "mocha": true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,30 @@
 sudo: false
 language: node_js
+
+# test node latest as last two stables
 node_js:
-- iojs
+- 0.10
+- 0.12
+- node
+
+# test browsers on node stable test
+matrix:
+  include:
+    - node: node
+      env: TEST_BROWSER=true
+
 script: npm run-script ci
+
 deploy:
   provider: npm
   email: mike@cousins.io
   api_key:
     secure: LRLw5Hp7huwE9YK9afd/ls3BMv4M0x2nm0iN4NSfNTaP9pvKZH6gLRaC/T2BmuDBN/R/OdEfoxvslk6lM6xlCuFAHBUpfdaDoe89uOUjOiZigcVLPoW0/M3iHu5PfFB/SoEy7SR90+9VZJjjx/or0jPqx2kk7seiwTiK4GHnxCTOUn3fCjzAUVUFKreCfjcvPiawiY9cRbPpWnB/1yHyvmjfIEwEe1lGnCJKq97NvTim/c7TzWIAMvzwQRqn6zVNhfXPS3vY/OioEuIFPOhKJFgchPHWOiaNy+5+w1CmTyWNSpyYkBN4R4QnxqHpgUITBTfMw9CVXV47fxUgkj581JJFmOK3qFm77l1Po2rGHNrTCgCAYqJvIsy+3wMdHBw6tOW1oprr3grUt1GR5mZ4U54D0RAoNT+MgMB+hqlkPGN7YQ6WTumLMY9ei3Sp5Zy/xeWuy4QLM4/oGA40RxdYVEL/SxQ+wlWm9Lm3Y95vshlxolznKfLviIwWKw+9oTSZZlvliO/m/UNgmUkI+Z2eNMk1FIv8xqUP7+l6W82GLU/LIt6J14oQv51UtfWcl6iNOCwQ6FJCxwLhtHK/rvVaEuRWq8jbIO1v111YbToVlZmcu6TRd/mIrCu9GIKQtBo/cRmdDn9st+7wyPROx+0NdhsdKoesyK6F6G8OoGpQnhs=
   on:
-    node: iojs
+    node: node
     tags: true
     all_branches: true
+
 env:
   global:
   - secure: qlkcT/LQrikO72X2xfwIxKN/rdDZ7oGCxe7fVBzCnpQ0Pt8ImDb4nboRQO6nyjtgA/gJqNs81Cl9rawTPuSKL/+DT1KVx/QHGNJ34yYafLmTB9//FkjhNx/dvAG4s/XiZ47rg0A9cZjx6AuXthD22XPzvgJwAtGoBjShuqUDjTJJCeyQCefuQPSE53wt8HNM0U2NuJvUlXEj9tXiKF15Ena3+ZbrBTSvFGWkmzKPNE/aUG9qDbNisvZyIE+Z/BlwvPjQ2owgGQAUY5ssXsGr6XkT8Rr7o1HBLBKkwU7lfkz+uhaNr/amU0bUx1XyBEHTp0j3Xu2WL2Z0AxVruJ9vVPg4SYoXDsd44M7rrVrVChxbpYfmfVA++8BosprqZB3nEUNUfQ5E6pq4/NIiOHTvfPBXsbuk3X6iLA7xQcFQl+Lzb8yZDZU2c10k8Z9wGZkQzyfk6Y0VuRoy5Pw4c/MW5u9y3AVk77Y/u1Km1lLQzf6t2GnJyb0tc+elgv4qtJi/rU4nseR7eBad5oJEJTKBVYw59bJjZCtGMVYuDXdEBqQUwDRW0IV6ZNGUf5DLpk3jyBaGVciIwxqivTE/WE2WDVurSUm8XJOr+B2p+tfSxhPm/7wN5QyqzdrcB+IhN8Fuk1j4g3S4hgk6DP5MWi5ZXyhhtniQ70VFzE8mSmT6NV8=

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ node_js:
 # test browsers on node stable test
 matrix:
   include:
-    - node: node
-      env: TEST_BROWSER=true
+    - node_js: node
+      env: TEST_BROWSERS=true
 
 script: npm run-script ci
 

--- a/.zuul.yml
+++ b/.zuul.yml
@@ -8,7 +8,3 @@ browsers:
     version: -1..latest
   - name: ie
     version: -1..latest
-browserify:
-  - transform: babelify
-  - require: babelify/polyfill.js
-    entry: true

--- a/README.md
+++ b/README.md
@@ -11,17 +11,13 @@ A printed circuit board Gerber and drill file parser. Implemented as a Node tran
 
 ## how to
 
-This module is written in ES2016, and thus requires iojs/Node >= v3.0.0. To run in the browser, it should be transpiled to ES5 with a tool like [Babel](https://babeljs.io/) and bundled with a tool like [browserify](http://browserify.org/) or [webpack](http://webpack.github.io/).
-
-Tested natively in iojs and with Babel and the Babel polyfill in the latest versions of Chrome, Safari, Firefox, and Internet Explorer.
-
 `$ npm install gerber-parser`
 
 ``` javascript
-const fs = require('fs')
-const gerberParser = require('gerber-parser')
+var fs = require('fs')
+var gerberParser = require('gerber-parser')
 
-const parser = gerberParser()
+var parser = gerberParser()
 parser.on('warning', function(w) {
   console.warn(`warning at line ${w.line}: ${w.message}`)
 })
@@ -33,13 +29,15 @@ fs.createReadStream('/path/to/gerber/file.gbr', {encoding: 'utf8'})
   })
 ```
 
+To run in the browser, this module should be bundled with a tool like [browserify](http://browserify.org/) or [webpack](http://webpack.github.io/).
+
 ## api
 
 See [API.md](./API.md)
 
 ## developing and contributing
 
-The code is written in ES2015 to run in "modern" versions of Node. Tests are written in [Mocha](http://mochajs.org/) and run in Node, [PhantomJS](http://phantomjs.org/), and a variety of browsers with [Zuul](https://github.com/defunctzombie/zuul) and [Open Sauce](https://saucelabs.com/opensauce/). All PRs should be accompanied by unit tests, with ideally one feature / bugfix per PR. Code linting happens with [ESLint](http://eslint.org/) automatically post-test and pre-commit.
+Tests are written in [Mocha](http://mochajs.org/) and run in Node, [PhantomJS](http://phantomjs.org/), and a variety of browsers with [Zuul](https://github.com/defunctzombie/zuul) and [Open Sauce](https://saucelabs.com/opensauce/). All PRs should be accompanied by unit tests, with ideally one feature / bugfix per PR. Code linting happens with [ESLint](http://eslint.org/) automatically post-test and pre-commit.
 
 Code is deployed on tags via [TravisCI](https://travis-ci.org/) and code coverage is tracked with [Coveralls](https://coveralls.io/).
 
@@ -48,9 +46,9 @@ Code is deployed on tags via [TravisCI](https://travis-ci.org/) and code coverag
 * `$ npm run lint` - lints code
 * `$ npm run test` - runs Node unit tests
 * `$ npm run test-watch` - runs unit tests and re-runs on changes
-* `$ npm run browser-test` - runs tests in a local browser
-* `$ npm run browser-test-phantom` - runs tests in PhantomJS
-* `$ npm run browser-test-sauce` - runs tests in Sauce Labs on multiple browsers
+* `$ npm run browser` - runs tests in a local browser
+* `$ npm run browser-phantom` - runs tests in PhantomJS
+* `$ npm run browser-sauce` - runs tests in Sauce Labs on multiple browsers
   * Sauce Labs account required
 * `$ npm run ci` - Script for CI server to run
   * Runs `npm test` and sends coverage report to Coveralls

--- a/lib/_apply-options.js
+++ b/lib/_apply-options.js
@@ -4,12 +4,12 @@
 
 var assign = require('lodash.assign')
 var pick = require('lodash.pick')
-var isFinite = require('lodash.isfinite')
+var numIsFinite = require('lodash.isfinite')
 
 var verifyPlaces = function(p) {
   var isAnArray = Array.isArray(p)
   var correctLength = (p.length === 2)
-  var finite = (isFinite(p[0]) && isFinite(p[1]))
+  var finite = (numIsFinite(p[0]) && numIsFinite(p[1]))
   return (isAnArray && correctLength && finite)
 }
 

--- a/lib/_apply-options.js
+++ b/lib/_apply-options.js
@@ -2,40 +2,41 @@
 // throws if invalid
 'use strict'
 
-const assign = require('lodash.assign')
-const pick = require('lodash.pick')
+var assign = require('lodash.assign')
+var pick = require('lodash.pick')
+var isFinite = require('lodash.isfinite')
 
-const verifyPlaces = function(p) {
-  const isAnArray = Array.isArray(p)
-  const correctLength = (p.length === 2)
-  const finite = (Number.isFinite(p[0]) && Number.isFinite(p[1]))
+var verifyPlaces = function(p) {
+  var isAnArray = Array.isArray(p)
+  var correctLength = (p.length === 2)
+  var finite = (isFinite(p[0]) && isFinite(p[1]))
   return (isAnArray && correctLength && finite)
 }
 
-const verifyZero = function(z) {
+var verifyZero = function(z) {
   return ((z === 'T') || (z === 'L'))
 }
 
-const verifyFiletype = function(f) {
+var verifyFiletype = function(f) {
   return ((f === 'gerber') || (f === 'drill'))
 }
 
-const verifyMap = {
+var verifyMap = {
   places: {check: verifyPlaces, err: 'places must be an array of two numbers 0-7'},
   zero: {check: verifyZero, err: "zero suppression must be 'L' or 'T'"},
   filetype: {check: verifyFiletype, err: "filetype must be 'drill' or 'gerber'"}
 }
 
-const pickOptions = function(value, key) {
-  const verification = verifyMap[key]
-  const result = verification.check(value)
+var pickOptions = function(value, key) {
+  var verification = verifyMap[key]
+  var result = verification.check(value)
   if (!result) {
     throw new Error(verification.err)
   }
   return result
 }
 
-const applyOptions = function(opts, target) {
+var applyOptions = function(opts, target) {
   assign(target, pick(opts, pickOptions))
 }
 

--- a/lib/_commands.js
+++ b/lib/_commands.js
@@ -1,31 +1,31 @@
 // factories to generate all possible parsed by a gerber command
 'use strict'
 
-const done = function() {
+var done = function() {
   return {cmd: 'done', line: -1}
 }
 
-const set = function(key, val) {
-  return {cmd: 'set', line: -1, key, val}
+var set = function(key, val) {
+  return {cmd: 'set', line: -1, key: key, val: val}
 }
 
-const level = function(key, val) {
-  return {cmd: 'level', line: -1, key, val}
+var level = function(key, val) {
+  return {cmd: 'level', line: -1, key: key, val: val}
 }
 
-const tool = function(key, val) {
-  return {cmd: 'tool', line: -1, key, val}
+var tool = function(key, val) {
+  return {cmd: 'tool', line: -1, key: key, val: val}
 }
 
-const op = function(key, val) {
-  return {cmd: 'op', line: -1, key, val}
+var op = function(key, val) {
+  return {cmd: 'op', line: -1, key: key, val: val}
 }
 
-const macro = function(key, val) {
-  return {cmd: 'macro', line: -1, key, val}
+var macro = function(key, val) {
+  return {cmd: 'macro', line: -1, key: key, val: val}
 }
 
-const commandMap = {
+var commandMap = {
   set: set, done: done, level: level, tool: tool, op: op, macro: macro
 }
 module.exports = commandMap

--- a/lib/_determine-filetype.js
+++ b/lib/_determine-filetype.js
@@ -1,14 +1,14 @@
 // function to determine filetype from a chunk
 'use strict'
 
-const determine = function(chunk, start, LIMIT) {
-  const limit = Math.min(LIMIT - start, chunk.length)
-  let current = []
-  let filetype = null
-  let index = -1
+var determine = function(chunk, start, LIMIT) {
+  var limit = Math.min(LIMIT - start, chunk.length)
+  var current = []
+  var filetype = null
+  var index = -1
 
   while((!filetype) && (++index < limit)) {
-    const c = chunk[index]
+    var c = chunk[index]
     if (c === '\n') {
       if (current.length + index) {
         filetype = 'drill'
@@ -17,7 +17,7 @@ const determine = function(chunk, start, LIMIT) {
     }
     else {
       current.push(c)
-      if ((c === '*') && current[0] !== ';') {
+      if ((c === '*') && (current[0] !== ';')) {
         filetype = 'gerber'
         current = []
       }

--- a/lib/_parse-drill.js
+++ b/lib/_parse-drill.js
@@ -2,42 +2,42 @@
 // takes a parser transform stream and a block string
 'use strict'
 
-// const map = require('lodash.map')
+var numIsFinite = require('lodash.isFinite')
 
-const commands = require('./_commands')
-const normalize = require('./normalize-coord')
-const parseCoord = require('./parse-coord')
+var commands = require('./_commands')
+var normalize = require('./normalize-coord')
+var parseCoord = require('./parse-coord')
 
-const reKI_HINT = /;FORMAT={(.):(.)\/ (absolute|.+)? \/ (metric|inch) \/.+(trailing|leading|decimal|keep)/
+var reKI_HINT = /;FORMAT={(.):(.)\/ (absolute|.+)? \/ (metric|inch) \/.+(trailing|leading|decimal|keep)/
 
-const reUNITS = /(INCH|METRIC)(?:,([TL])Z)?/
-const reTOOL_DEF = /T0*(\d+)C([\d.]+)/
-const reTOOL_SET = /T0*(\d+)(?!C)/
-const reCOORD = /((?:[XY][+-]?[\d.]+){1,2})/
+var reUNITS = /(INCH|METRIC)(?:,([TL])Z)?/
+var reTOOL_DEF = /T0*(\d+)C([\d.]+)/
+var reTOOL_SET = /T0*(\d+)(?!C)/
+var reCOORD = /((?:[XY][+-]?[\d.]+){1,2})/
 
-const setUnits = function(parser, units) {
-  const format = (units === 'in') ? [2, 4] : [3, 3]
+var setUnits = function(parser, units) {
+  var format = (units === 'in') ? [2, 4] : [3, 3]
   if (parser.format.places.length === 0) {
     parser.format.places = format
   }
   return parser._push(commands.set('units', units))
 }
 
-const parse = function(parser, block) {
+var parse = function(parser, block) {
   // ignore comments
   if (block[0] === ';') {
 
     // check for kicad format hints
     if (reKI_HINT.test(block)) {
-      const kicadMatch = block.match(reKI_HINT)
-      const leading = Number(kicadMatch[1])
-      const trailing = Number(kicadMatch[2])
-      const absolute = kicadMatch[3]
-      const units = kicadMatch[4]
-      const suppression = kicadMatch[5]
+      var kicadMatch = block.match(reKI_HINT)
+      var leading = Number(kicadMatch[1])
+      var trailing = Number(kicadMatch[2])
+      var absolute = kicadMatch[3]
+      var unitSet = kicadMatch[4]
+      var suppressionSet = kicadMatch[5]
 
       // set format if we got numbers
-      if (!Number.isNaN(leading) && !Number.isNaN(trailing)) {
+      if (numIsFinite(leading) && numIsFinite(trailing)) {
         parser.format.places = [leading, trailing]
       }
 
@@ -50,7 +50,7 @@ const parse = function(parser, block) {
       }
 
       // send units
-      if (units === 'metric') {
+      if (unitSet === 'metric') {
         parser._push(commands.set('backupUnits', 'mm'))
       }
       else {
@@ -58,10 +58,10 @@ const parse = function(parser, block) {
       }
 
       // set zero suppression
-      if (suppression === 'leading' || suppression === 'keep') {
+      if (suppressionSet === 'leading' || suppressionSet === 'keep') {
         parser.format.zero = 'L'
       }
-      else if (suppression === 'trailing') {
+      else if (suppressionSet === 'trailing') {
         parser.format.zero = 'T'
       }
       else {
@@ -73,21 +73,21 @@ const parse = function(parser, block) {
   }
 
   if (reTOOL_DEF.test(block)) {
-    const toolMatch = block.match(reTOOL_DEF)
-    const toolCode = toolMatch[1]
-    const toolDia = normalize(toolMatch[2])
-    const tool = {shape: 'circle', val: [toolDia], hole: []}
+    var toolMatch = block.match(reTOOL_DEF)
+    var toolCode = toolMatch[1]
+    var toolDia = normalize(toolMatch[2])
+    var toolDef = {shape: 'circle', val: [toolDia], hole: []}
 
-    return parser._push(commands.tool(toolCode, tool))
+    return parser._push(commands.tool(toolCode, toolDef))
   }
 
   // tool set
   if (reTOOL_SET.test(block)) {
-    const tool = block.match(reTOOL_SET)[1]
+    var toolSet = block.match(reTOOL_SET)[1]
 
     // allow tool set to fall through because it can happen on the
     // same line as a coordinate operation
-    parser._push(commands.set('tool', tool))
+    parser._push(commands.set('tool', toolSet))
   }
 
   // operations
@@ -103,8 +103,8 @@ const parse = function(parser, block) {
       parser._warn('places format missing; assuming [2, 4]')
     }
 
-    const coordMatch = block.match(reCOORD)
-    const coord = parseCoord(coordMatch[1], parser.format)
+    var coordMatch = block.match(reCOORD)
+    var coord = parseCoord(coordMatch[1], parser.format)
     return parser._push(commands.op('flash', coord))
   }
 
@@ -129,9 +129,9 @@ const parse = function(parser, block) {
   }
 
   if (reUNITS.test(block)) {
-    const unitsMatch = block.match(reUNITS)
-    const units = unitsMatch[1]
-    const suppression = unitsMatch[2]
+    var unitsMatch = block.match(reUNITS)
+    var units = unitsMatch[1]
+    var suppression = unitsMatch[2]
 
     if (units === 'METRIC') {
       setUnits(parser, 'mm')

--- a/lib/_parse-drill.js
+++ b/lib/_parse-drill.js
@@ -2,7 +2,7 @@
 // takes a parser transform stream and a block string
 'use strict'
 
-var numIsFinite = require('lodash.isFinite')
+var numIsFinite = require('lodash.isfinite')
 
 var commands = require('./_commands')
 var normalize = require('./normalize-coord')

--- a/lib/_parse-gerber.js
+++ b/lib/_parse-gerber.js
@@ -2,46 +2,46 @@
 // takes a parser transform stream and a block string
 'use strict'
 
-const map = require('lodash.map')
+var map = require('lodash.map')
 
-const commands = require('./_commands')
-const normalize = require('./normalize-coord')
-const parseCoord = require('./parse-coord')
-const parseMacroBlock = require('./_parse-macro-block')
+var commands = require('./_commands')
+var normalize = require('./normalize-coord')
+var parseCoord = require('./parse-coord')
+var parseMacroBlock = require('./_parse-macro-block')
 
 // g-code set matchers
-const reMODE = /^G0*([123])/
-const reREGION = /^G3([67])/
-const reARC = /^G7([45])/
-const reBKP_UNITS = /^G7([01])/
-const reCOMMENT = /^G0*4/
+var reMODE = /^G0*([123])/
+var reREGION = /^G3([67])/
+var reARC = /^G7([45])/
+var reBKP_UNITS = /^G7([01])/
+var reCOMMENT = /^G0*4/
 
 // tool changes
-const reTOOL = /^(?:G54)?D0*([1-9]\d+)/
+var reTOOL = /^(?:G54)?D0*([1-9]\d+)/
 
 // operations
-const reCOORD = /((?:[XYIJ][+-]?\d+){1,4})/
-const reOP = /D0*([123])$/
+var reCOORD = /((?:[XYIJ][+-]?\d+){1,4})/
+var reOP = /D0*([123])$/
 
 // parameter code matchers
-const reUNITS = /^%MO(IN|MM)/
+var reUNITS = /^%MO(IN|MM)/
 // format spec regexp courtesy @summivox
-const reFORMAT = /^%FS([LT]?)([AI]?)X([0-7])([0-7])Y\3\4/
-const rePOLARITY = /^%LP([CD])/
-const reSTEP_REP = /^%SR(?:X(\d+)Y(\d+)I([\d.]+)J([\d.]+))?/
-const reTOOL_DEF = /^%ADD(\d{2,})([A-Za-z_]\w*)(?:,((?:X?[\d.]+)*))?/
-const reMACRO = /^%AM([A-Za-z_]\w*)\*?(.*)/
+var reFORMAT = /^%FS([LT]?)([AI]?)X([0-7])([0-7])Y\3\4/
+var rePOLARITY = /^%LP([CD])/
+var reSTEP_REP = /^%SR(?:X(\d+)Y(\d+)I([\d.]+)J([\d.]+))?/
+var reTOOL_DEF = /^%ADD(\d{2,})([A-Za-z_]\w*)(?:,((?:X?[\d.]+)*))?/
+var reMACRO = /^%AM([A-Za-z_]\w*)\*?(.*)/
 
-const parseToolDef = function(parser, block) {
-  const format = {places: parser.format.places}
-  const toolMatch = block.match(reTOOL_DEF)
-  const tool = toolMatch[1]
-  const shapeMatch = toolMatch[2]
-  const toolArgs = (toolMatch[3]) ? toolMatch[3].split('X') : []
+var parseToolDef = function(parser, block) {
+  var format = {places: parser.format.places}
+  var toolMatch = block.match(reTOOL_DEF)
+  var tool = toolMatch[1]
+  var shapeMatch = toolMatch[2]
+  var toolArgs = (toolMatch[3]) ? toolMatch[3].split('X') : []
 
   // get the shape
-  let shape
-  let maxArgs
+  var shape
+  var maxArgs
   if (shapeMatch === 'C') {
     shape = 'circle'
     maxArgs = 3
@@ -63,7 +63,7 @@ const parseToolDef = function(parser, block) {
     maxArgs = 0
   }
 
-  let val
+  var val
   if (shape === 'circle') {
     val = [normalize(toolArgs[0], format)]
   }
@@ -80,7 +80,7 @@ const parseToolDef = function(parser, block) {
     val = map(toolArgs, Number)
   }
 
-  let hole = []
+  var hole = []
   if (toolArgs[maxArgs - 1]) {
     hole = [
       normalize(toolArgs[maxArgs - 2], format),
@@ -90,20 +90,20 @@ const parseToolDef = function(parser, block) {
   else if (toolArgs[maxArgs - 2]) {
     hole = [normalize(toolArgs[maxArgs - 2], format)]
   }
-  const toolDef = {shape, val, hole}
+  var toolDef = {shape: shape, val: val, hole: hole}
   return parser._push(commands.tool(tool, toolDef))
 }
 
-const parseMacroDef = function(parser, block) {
-  const macroMatch = block.match(reMACRO)
-  const name = macroMatch[1]
-  const blockMatch = (macroMatch[2].length) ? macroMatch[2].split('*') : []
-  const blocks = map(blockMatch, parseMacroBlock, parser)
+var parseMacroDef = function(parser, block) {
+  var macroMatch = block.match(reMACRO)
+  var name = macroMatch[1]
+  var blockMatch = (macroMatch[2].length) ? macroMatch[2].split('*') : []
+  var blocks = map(blockMatch, parseMacroBlock, parser)
 
   return parser._push(commands.macro(name, blocks))
 }
 
-const parse = function(parser, block) {
+var parse = function(parser, block) {
   if (reCOMMENT.test(block)) {
     return
   }
@@ -113,36 +113,36 @@ const parse = function(parser, block) {
   }
 
   if (reREGION.test(block)) {
-    const regionMatch = block.match(reREGION)[1]
-    const region = (regionMatch === '6') ? true : false
+    var regionMatch = block.match(reREGION)[1]
+    var region = (regionMatch === '6') ? true : false
     return parser._push(commands.set('region', region))
   }
 
   if (reARC.test(block)) {
-    const arcMatch = block.match(reARC)[1]
-    const arc = (arcMatch === '4') ? 's' : 'm'
+    var arcMatch = block.match(reARC)[1]
+    var arc = (arcMatch === '4') ? 's' : 'm'
     return parser._push(commands.set('arc', arc))
   }
 
   if (reUNITS.test(block)) {
-    const unitsMatch = block.match(reUNITS)[1]
-    const units = (unitsMatch === 'IN') ? 'in' : 'mm'
+    var unitsMatch = block.match(reUNITS)[1]
+    var units = (unitsMatch === 'IN') ? 'in' : 'mm'
     return parser._push(commands.set('units', units))
   }
 
   if (reBKP_UNITS.test(block)) {
-    const bkpUnitsMatch = block.match(reBKP_UNITS)[1]
-    const backupUnits = (bkpUnitsMatch === '0') ? 'in' : 'mm'
+    var bkpUnitsMatch = block.match(reBKP_UNITS)[1]
+    var backupUnits = (bkpUnitsMatch === '0') ? 'in' : 'mm'
     return parser._push(commands.set('backupUnits', backupUnits))
   }
 
   if (reFORMAT.test(block)) {
-    const formatMatch = block.match(reFORMAT)
-    const zero = formatMatch[1]
-    const nota = formatMatch[2]
-    const leading = Number(formatMatch[3])
-    const trailing = Number(formatMatch[4])
-    const format = parser.format
+    var formatMatch = block.match(reFORMAT)
+    var zero = formatMatch[1]
+    var nota = formatMatch[2]
+    var leading = Number(formatMatch[3])
+    var trailing = Number(formatMatch[4])
+    var format = parser.format
 
     format.zero = format.zero || zero
     if (!format.places.length) {
@@ -158,29 +158,29 @@ const parse = function(parser, block) {
       parser._warn('trailing zero suppression has been deprecated')
     }
 
-    const epsilon = 1.5 * Math.pow(10, -parser.format.places[1])
+    var epsilon = 1.5 * Math.pow(10, -parser.format.places[1])
     parser._push(commands.set('nota', nota))
     parser._push(commands.set('epsilon', epsilon))
     return
   }
 
   if (rePOLARITY.test(block)) {
-    const polarity = block.match(rePOLARITY)[1]
+    var polarity = block.match(rePOLARITY)[1]
     return parser._push(commands.level('polarity', polarity))
   }
 
   if (reSTEP_REP.test(block)) {
-    const stepRepeatMatch = block.match(reSTEP_REP)
-    const x = stepRepeatMatch[1] || 1
-    const y = stepRepeatMatch[2] || 1
-    const i = stepRepeatMatch[3] || 0
-    const j = stepRepeatMatch[4] || 0
-    const sr = {x: Number(x), y: Number(y), i: Number(i), j: Number(j)}
+    var stepRepeatMatch = block.match(reSTEP_REP)
+    var x = stepRepeatMatch[1] || 1
+    var y = stepRepeatMatch[2] || 1
+    var i = stepRepeatMatch[3] || 0
+    var j = stepRepeatMatch[4] || 0
+    var sr = {x: Number(x), y: Number(y), i: Number(i), j: Number(j)}
     return parser._push(commands.level('stepRep', sr))
   }
 
   if (reTOOL.test(block)) {
-    const tool = block.match(reTOOL)[1]
+    var tool = block.match(reTOOL)[1]
     return parser._push(commands.set('tool', tool))
   }
 
@@ -194,13 +194,13 @@ const parse = function(parser, block) {
 
   // finally, look for mode commands and operations
   // they may appear in the same block
-  const coordMatch = block.match(reCOORD)
-  const opMatch = block.match(reOP)
-  const modeMatch = block.match(reMODE)
+  var coordMatch = block.match(reCOORD)
+  var opMatch = block.match(reOP)
+  var modeMatch = block.match(reMODE)
 
   if (opMatch || coordMatch || modeMatch) {
     if (modeMatch) {
-      let mode
+      var mode
       if (modeMatch[1] === '1') {
         mode = 'i'
       }
@@ -214,11 +214,11 @@ const parse = function(parser, block) {
     }
 
     if (opMatch || coordMatch) {
-      const opCode = (opMatch) ? opMatch[1] : ''
-      const coordString = (coordMatch) ? coordMatch[1] : ''
-      const coord = parseCoord(coordString, parser.format)
+      var opCode = (opMatch) ? opMatch[1] : ''
+      var coordString = (coordMatch) ? coordMatch[1] : ''
+      var coord = parseCoord(coordString, parser.format)
 
-      let op = 'last'
+      var op = 'last'
       if (opCode === '1') {
         op = 'int'
       }
@@ -236,7 +236,7 @@ const parse = function(parser, block) {
   }
 
   // if we reach here the block was unhandled, so warn if it is not empty
-  return parser._warn(`block "${block}" was not recognized and was ignored`)
+  return parser._warn('block "' + block + '" was not recognized and was ignored')
 }
 
 module.exports = parse

--- a/lib/_parse-macro-block.js
+++ b/lib/_parse-macro-block.js
@@ -1,18 +1,19 @@
 // function to parse a macro block into a primitive object
 'use strict'
 
-const map = require('lodash.map')
-const clone = require('lodash.clone')
-const set = require('lodash.set')
+var map = require('lodash.map')
+var clone = require('lodash.clone')
+var set = require('lodash.set')
+var bind = require('lodash.bind')
 
-const parseMacroExpr = require('./_parse-macro-expression')
+var parseMacroExpr = require('./_parse-macro-expression')
 
-const reEXPR = /[\$+\-\/xX]/
-const reVAR_DEF = /^(\$[\d+])=(.+)/
+var reEXPR = /[\$+\-\/xX]/
+var reVAR_DEF = /^(\$[\d+])=(.+)/
 
 // CAUTION: assumes parser will be bound to this
-const parseMacroBlock = function(block) {
-  const parseExpr = parseMacroExpr.bind(this)
+var parseMacroBlock = function(block) {
+  var parseExpr = bind(parseMacroExpr, this)
 
   // check first for a comment
   if (block[0] === '0') {
@@ -21,32 +22,32 @@ const parseMacroBlock = function(block) {
 
   // variable definition
   if (reVAR_DEF.test(block)) {
-    const varDefMatch = block.match(reVAR_DEF)
-    const varName = varDefMatch[1]
-    const varExpr = varDefMatch[2]
-    const evaluate = parseExpr(varExpr)
+    var varDefMatch = block.match(reVAR_DEF)
+    var varName = varDefMatch[1]
+    var varExpr = varDefMatch[2]
+    var evaluate = parseExpr(varExpr)
 
-    const setMods = function(mods) {
+    var setMods = function(mods) {
       return set(clone(mods), varName, evaluate(mods))
     }
     return {type: 'variable', set: setMods}
   }
 
   // map a primitive param to a number or, if an expression, a function
-  const modVal = function(m) {
+  var modVal = function(m) {
     if (reEXPR.test(m)){
       return parseExpr(m)
     }
     return Number(m)
   }
 
-  const mods = map(block.split(','), modVal)
-  const code = mods[0]
-  const exp = mods[1]
+  var mods = map(block.split(','), modVal)
+  var code = mods[0]
+  var exp = mods[1]
 
   // circle primitive
   if (code === 1) {
-    return {type: 'circle', exp, dia: mods[2], cx: mods[3], cy: mods[4]}
+    return {type: 'circle', exp: exp, dia: mods[2], cx: mods[3], cy: mods[4]}
   }
 
   // vector primitive
@@ -57,7 +58,7 @@ const parseMacroBlock = function(block) {
   if (code === 2 || code === 20) {
     return {
       type: 'vect',
-      exp,
+      exp: exp,
       width: mods[2],
       x1: mods[3],
       y1: mods[4],
@@ -71,7 +72,7 @@ const parseMacroBlock = function(block) {
   if (code === 21) {
     return {
       type: 'rect',
-      exp,
+      exp: exp,
       width: mods[2],
       height: mods[3],
       cx: mods[4],
@@ -84,7 +85,7 @@ const parseMacroBlock = function(block) {
     this._warn('macro apeture lower-left rectangle primitives are deprecated')
     return {
       type: 'rectLL',
-      exp,
+      exp: exp,
       width: mods[2],
       height: mods[3],
       x: mods[4],
@@ -96,7 +97,7 @@ const parseMacroBlock = function(block) {
   if (code === 4) {
     return {
       type: 'outline',
-      exp,
+      exp: exp,
       points: map(mods.slice(3, -1), Number),
       rot: Number(mods[mods.length - 1])
     }
@@ -105,7 +106,7 @@ const parseMacroBlock = function(block) {
   if (code === 5) {
     return {
       type: 'poly',
-      exp,
+      exp: exp,
       vertices: mods[2],
       cx: mods[3],
       cy: mods[4],
@@ -117,7 +118,7 @@ const parseMacroBlock = function(block) {
   if (code === 6) {
     return {
       type: 'moire',
-      exp,
+      exp: exp,
       cx: mods[2],
       cy: mods[3],
       dia: mods[4],
@@ -133,7 +134,7 @@ const parseMacroBlock = function(block) {
   if (code === 7) {
     return {
       type: 'thermal',
-      exp,
+      exp: exp,
       cx: mods[2],
       cy: mods[3],
       outerDia: mods[4],
@@ -144,7 +145,7 @@ const parseMacroBlock = function(block) {
   }
 
   else {
-    this._warn(`${code} is an unrecognized primitive for a macro apeture`)
+    this._warn(code + ' is an unrecognized primitive for a macro apeture')
   }
 }
 

--- a/lib/_parse-macro-expression.js
+++ b/lib/_parse-macro-expression.js
@@ -1,26 +1,27 @@
 // parse a macro expression and return a function that takes mods
 'use strict'
 
-const partial = require('lodash.partial')
+var partial = require('lodash.partial')
 
-const reOP = /[+\-\/xX()]/
-const reNUMBER = /[$\d.]+/
-const reTOKEN = new RegExp([reOP.source, reNUMBER.source].join('|'), 'g')
+var reOP = /[+\-\/xX()]/
+var reNUMBER = /[$\d.]+/
+var reTOKEN = new RegExp([reOP.source, reNUMBER.source].join('|'), 'g')
 
 // expects this to be bound to the parser
-const parseMacroExpression = function(expr) {
+var parseMacroExpression = function(expr) {
   // parser
-  const parser = this
+  var parser = this
   // tokenize the expression
-  const tokens = expr.match(reTOKEN)
+  var tokens = expr.match(reTOKEN)
 
   // forward declare parse expression
-  let parseExpression
+  var parseExpression
 
   // primary tokens are numbers and parentheses
-  const parsePrimary = function() {
-    const t = tokens.shift()
-    let exp
+  var parsePrimary = function() {
+    var t = tokens.shift()
+    var exp
+
     if (reNUMBER.test(t)) {
       exp = {type: 'n', val: t}
     }
@@ -32,16 +33,17 @@ const parseMacroExpression = function(expr) {
   }
 
   // parse multiplication and division tokens
-  const parseMultiplication = function() {
-    let exp = parsePrimary()
-    let t = tokens[0]
+  var parseMultiplication = function() {
+    var exp = parsePrimary()
+    var t = tokens[0]
+
     if (t === 'X') {
       parser._warn("multiplication in macros should use 'x', not 'X'")
       t = 'x'
     }
     while ((t === 'x') || (t === '/')) {
       tokens.shift()
-      const right = parsePrimary()
+      var right = parsePrimary()
       exp = {type: t, left: exp, right: right}
       t = tokens[0]
     }
@@ -50,11 +52,11 @@ const parseMacroExpression = function(expr) {
 
   // parse addition and subtraction tokens
   parseExpression = function() {
-    let exp = parseMultiplication()
-    let t = tokens[0]
+    var exp = parseMultiplication()
+    var t = tokens[0]
     while ((t === '+') || (t === '-')) {
       tokens.shift()
-      const right = parseMultiplication()
+      var right = parseMultiplication()
       exp = {type: t, left: exp, right: right}
       t = tokens[0]
     }
@@ -62,18 +64,18 @@ const parseMacroExpression = function(expr) {
   }
 
   // parse the expression string into a binary tree
-  const tree = parseExpression()
+  var tree = parseExpression()
 
   // evalute by recursively traversing the tree
-  const evaluate = function(op, mods) {
-    const getValue = function(t) {
+  var evaluate = function(op, mods) {
+    var getValue = function(t) {
       if (t[0] === '$') {
         return Number(mods[t])
       }
       return Number(t)
     }
 
-    const type = op.type
+    var type = op.type
     if (type === 'n') {
       return getValue(op.val)
     }

--- a/lib/_warning.js
+++ b/lib/_warning.js
@@ -1,8 +1,8 @@
 // simple warning class to be emitted when something questionable in the gerber is found
 'use strict'
 
-const warning = function(message, line) {
-  return {message, line}
+var warning = function(message, line) {
+  return {message: message, line: line}
 }
 
 module.exports = warning

--- a/lib/gerber-parser.js
+++ b/lib/gerber-parser.js
@@ -1,7 +1,7 @@
 // generic file parser for gerber and drill files
 'use strict'
 
-var Transform = require('stream').Transform
+var Transform = require('readable-stream').Transform
 
 var applyOptions = require('./_apply-options')
 var determineFiletype = require('./_determine-filetype')

--- a/lib/gerber-parser.js
+++ b/lib/gerber-parser.js
@@ -1,21 +1,23 @@
 // generic file parser for gerber and drill files
 'use strict'
 
-const Transform = require('stream').Transform
+var Transform = require('stream').Transform
 
-const applyOptions = require('./_apply-options')
-const determineFiletype = require('./_determine-filetype')
-const getNext = require('./get-next-block')
-const parseGerber = require('./_parse-gerber')
-const parseDrill = require('./_parse-drill')
-const warning = require('./_warning')
+var applyOptions = require('./_apply-options')
+var determineFiletype = require('./_determine-filetype')
+var getNext = require('./get-next-block')
+var parseGerber = require('./_parse-gerber')
+var parseDrill = require('./_parse-drill')
+var warning = require('./_warning')
 
-const LIMIT = 65535
+var LIMIT = 65535
 
-const _transform = function(chunk, encoding, done) {
+var _transform = function(chunk, encoding, done) {
+  var filetype = this.format.filetype
+
   // determine filetype within 65535 characters
-  if (!this.format.filetype) {
-    const filetype = determineFiletype(chunk, this._index, LIMIT)
+  if (!filetype) {
+    filetype = determineFiletype(chunk, this._index, LIMIT)
     this._index += chunk.length
 
     if (!filetype) {
@@ -31,11 +33,11 @@ const _transform = function(chunk, encoding, done) {
     }
   }
 
-  const filetype = this.format.filetype
-  const toProcess = this._stash + chunk
+  var toProcess = this._stash + chunk
   this._stash = ''
+
   while (this._index < toProcess.length) {
-    const next = getNext(filetype, toProcess, this._index)
+    var next = getNext(filetype, toProcess, this._index)
     this._index += next.read
     this.line += next.lines
     this._stash += next.rem
@@ -54,18 +56,18 @@ const _transform = function(chunk, encoding, done) {
   done()
 }
 
-const _push = function(data) {
+var _push = function(data) {
   data.line = this.line
   this.push(data)
 }
 
-const _warn = function(message) {
+var _warn = function(message) {
   this.emit('warning', warning(message, this.line))
 }
 
-const parser = function(opts) {
+var parser = function(opts) {
   // create a transform stream
-  const stream = new Transform({
+  var stream = new Transform({
     decodeStrings: false,
     readableObjectMode: true
   })

--- a/lib/get-next-block.js
+++ b/lib/get-next-block.js
@@ -2,29 +2,29 @@
 // returns {next: '_', read: [chars read], lines: [lines read]}
 'use strict'
 
-const getNext = function(type, chunk, start) {
+var getNext = function(type, chunk, start) {
   if (type !== 'gerber' && type !== 'drill') {
     throw new Error('filetype to get next block must be "drill" or "gerber"')
   }
 
   // parsing constants
-  const limit = chunk.length - start
-  const split = (type === 'gerber') ? '*' : '\n'
-  const param = (type === 'gerber') ? '%' : ''
+  var limit = chunk.length - start
+  var split = (type === 'gerber') ? '*' : '\n'
+  var param = (type === 'gerber') ? '%' : ''
 
   // search flags
-  let splitFound = false
-  let paramStarted = false
-  let paramFound = false
-  let blockFound = false
+  var splitFound = false
+  var paramStarted = false
+  var paramFound = false
+  var blockFound = false
 
   // chunk results
-  const found = []
-  let read = 0
-  let lines = 0
+  var found = []
+  var read = 0
+  var lines = 0
 
   while ((!blockFound) && (read < limit)) {
-    const c = chunk[start + read]
+    var c = chunk[start + read]
 
     // count newlines
     if (c === '\n') {
@@ -56,9 +56,9 @@ const getNext = function(type, chunk, start) {
     blockFound = (splitFound && ((!paramStarted) || paramFound))
   }
 
-  const block = (blockFound) ? found.join('') : ''
-  const rem = (!blockFound) ? found.join('') : ''
-  return {lines, read, block, rem}
+  var block = (blockFound) ? found.join('') : ''
+  var rem = (!blockFound) ? found.join('') : ''
+  return {lines: lines, read: read, block: block, rem: rem}
 }
 
 module.exports = getNext

--- a/lib/normalize-coord.js
+++ b/lib/normalize-coord.js
@@ -2,21 +2,21 @@
 // coordinate is 1000x the gerber unit
 'use strict'
 
-// svg coordinate scaling factor and power of ten exponent
-// const COORD_E = 3
+var isFinite = require('lodash.isfinite')
+var padLeft = require('lodash.padleft')
+var padRight = require('lodash.padright')
 
 // function takes in the number string to be converted and the format object
-const normalizeCoord = function(number, format) {
+var normalizeCoord = function(number, format) {
   // make sure we're dealing with a string
   if (number == null) {
     return NaN
   }
-  let numberString = '' + number
+
+  var numberString = '' + number
 
   // pull out the sign and get the before and after segments ready
-  let before = ''
-  let after = ''
-  let sign = '+'
+  var sign = '+'
   if ((numberString[0] === '-') || (numberString[0] === '+')) {
     sign = numberString[0]
     numberString = numberString.slice(1)
@@ -24,53 +24,30 @@ const normalizeCoord = function(number, format) {
 
   // check if the number has a decimal point or has been explicitely flagged
   // if it does, just split by the decimal point to get leading and trailing
-  if (numberString.includes('.') || (format == null) || (format.zero == null)) {
+  var hasDecimal = (numberString.indexOf('.') !== -1)
+  if (hasDecimal || (format == null) || (format.zero == null)) {
     return Number(sign + numberString)
   }
 
   // otherwise we need to use the number format to split up the string
   else {
-    const numberStringLen = numberString.length
-
     // make sure format is valid
     if (format.places == null || format.places.length !== 2) {
       return NaN
     }
 
-    const leading = format.places[0]
-    const trailing = format.places[1]
-    if (!Number.isFinite(leading) || !Number.isFinite(trailing)) {
+    var leading = format.places[0]
+    var trailing = format.places[1]
+    if (!isFinite(leading) || !isFinite(trailing)) {
       return NaN
     }
 
-    // split according to trailing or leading zero suppression
+    // pad according to trailing or leading zero suppression
     if (format.zero === 'T') {
-      for (let i = 0; i < numberStringLen; i++) {
-        const c = numberString[i]
-        if (i < leading) {
-          before += c
-        }
-        else {
-          after += c
-        }
-      }
-
-      // pad any missing zeros
-      before += '0'.repeat(Math.max(0, (leading - before.length)))
+      numberString = padRight(numberString, leading + trailing, '0')
     }
     else if (format.zero === 'L') {
-      for (let i = 0; i < numberStringLen; i++) {
-        const c = numberString[i]
-        if (numberString.length - i <= trailing) {
-          after += c
-        }
-        else {
-          before += c
-        }
-      }
-
-      // pad any missing zeros
-      after = '0'.repeat(Math.max(0, (trailing - after.length))) + after
+      numberString = padLeft(numberString, leading + trailing, '0')
     }
     else {
       return NaN
@@ -78,7 +55,9 @@ const normalizeCoord = function(number, format) {
   }
 
   // finally, parse the numberString
-  return Number([sign + before, after].join('.'))
+  var before = numberString.slice(0, leading)
+  var after = numberString.slice(leading, leading + trailing)
+  return Number(sign + before + '.' + after)
 }
 
 module.exports = normalizeCoord

--- a/lib/normalize-coord.js
+++ b/lib/normalize-coord.js
@@ -2,7 +2,7 @@
 // coordinate is 1000x the gerber unit
 'use strict'
 
-var isFinite = require('lodash.isfinite')
+var numIsFinite = require('lodash.isfinite')
 var padLeft = require('lodash.padleft')
 var padRight = require('lodash.padright')
 
@@ -38,7 +38,7 @@ var normalizeCoord = function(number, format) {
 
     var leading = format.places[0]
     var trailing = format.places[1]
-    if (!isFinite(leading) || !isFinite(trailing)) {
+    if (!numIsFinite(leading) || !numIsFinite(trailing)) {
       return NaN
     }
 

--- a/lib/parse-coord.js
+++ b/lib/parse-coord.js
@@ -3,17 +3,19 @@
 // returns an object of {x: number, y: number, etc} for coordinates it finds
 'use strict'
 
-// convert to normalized number
-const normalize = require('./normalize-coord')
+var transform = require('lodash.transform')
 
-const MATCH = {
+// convert to normalized number
+var normalize = require('./normalize-coord')
+
+var MATCH = {
   x: /X([+-]?[\d\.]+)/,
   y: /Y([+-]?[\d\.]+)/,
   i: /I([+-]?[\d\.]+)/,
   j: /J([+-]?[\d\.]+)/
 }
 
-const parse = function(coord, format) {
+var parse = function(coord, format) {
   if (coord == null) {
     return {}
   }
@@ -22,17 +24,15 @@ const parse = function(coord, format) {
     throw new Error('cannot parse coordinate with format undefined')
   }
 
-  const parse = {}
-
   // pull out the x, y, i, and j
-  for (const c of Object.keys(MATCH)) {
-    const match = coord.match(MATCH[c])
-    if (match) {
-      parse[c] = normalize(match[1], format)
+  var parsed = transform(MATCH, function(result, matcher, c) {
+    var coordMatch = coord.match(matcher)
+    if (coordMatch) {
+      result[c] = normalize(coordMatch[1], format)
     }
-  }
+  })
 
-  return parse
+  return parsed
 }
 
 module.exports = parse

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "browser": "zuul --local -- ./test/*_test.js",
     "browser-phantom": "zuul --phantom -- ./test/*_test.js",
     "browser-sauce": "zuul -- ./test/*_test.js",
-    "ci": "npm run test && ([ \"${TEST_BROWSERS}\" = \"true\" ] && npm run ci-browser) || true",
+    "ci": "npm run test && ([ \"${TEST_BROWSERS}\" = \"true\" ] && npm run ci-browser || true)",
     "ci-browser": "[ \"${TRAVIS_PULL_REQUEST}\" = \"false\" ] && npm run browser-sauce || true",
     "postci": "coveralls < ./coverage/lcov.info"
   },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "lodash.partial": "^3.1.1",
     "lodash.pick": "^3.1.0",
     "lodash.set": "^3.7.4",
-    "lodash.transform": "^3.0.4"
+    "lodash.transform": "^3.0.4",
+    "readable-stream": "^2.0.2"
   },
   "devDependencies": {
     "chai": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "test": "istanbul cover --include-all-sources _mocha",
     "posttest": "npm run lint",
     "test-watch": "mocha --reporter dot --watch",
-    "browser-test": "zuul --local -- ./test/*_test.js",
-    "browser-test-phantom": "zuul --phantom -- ./test/*_test.js",
-    "browser-test-sauce": "zuul -- ./test/*_test.js",
-    "ci": "npm run test && npm run ci-no-pr",
-    "ci-no-pr": "[ \"${TRAVIS_PULL_REQUEST}\" = \"false\" ] && npm run browser-test-sauce || true",
+    "browser": "zuul --local -- ./test/*_test.js",
+    "browser-phantom": "zuul --phantom -- ./test/*_test.js",
+    "browser-sauce": "zuul -- ./test/*_test.js",
+    "ci": "npm run test && ([ \"${TEST_BROWSERS}\" = \"true\" ] && npm run ci-browser) || true",
+    "ci-browser": "[ \"${TRAVIS_PULL_REQUEST}\" = \"false\" ] && npm run browser-sauce || true",
     "postci": "coveralls < ./coverage/lcov.info"
   },
   "precommit": [
@@ -44,19 +44,24 @@
   "homepage": "https://github.com/mcous/gerber-parser#readme",
   "dependencies": {
     "lodash.assign": "^3.2.0",
+    "lodash.bind": "^3.1.0",
     "lodash.clone": "^3.0.3",
+    "lodash.isfinite": "^3.2.0",
     "lodash.map": "^3.1.4",
+    "lodash.padleft": "^3.1.1",
+    "lodash.padright": "^3.1.1",
     "lodash.partial": "^3.1.1",
     "lodash.pick": "^3.1.0",
-    "lodash.set": "^3.7.4"
+    "lodash.set": "^3.7.4",
+    "lodash.transform": "^3.0.4"
   },
   "devDependencies": {
-    "babelify": "^6.3.0",
     "chai": "^3.2.0",
     "coveralls": "^2.11.4",
     "eslint": "^1.3.1",
     "istanbul": "^0.3.19",
     "lodash.bind": "^3.1.0",
+    "lodash.repeat": "^3.0.1",
     "mocha": "^2.3.0",
     "phantomjs": "^1.9.18",
     "pre-commit": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "coveralls": "^2.11.4",
     "eslint": "^1.3.1",
     "istanbul": "^0.3.19",
-    "lodash.bind": "^3.1.0",
     "lodash.repeat": "^3.0.1",
     "mocha": "^2.3.0",
     "phantomjs": "^1.9.18",

--- a/test/gerber-parser_drill_test.js
+++ b/test/gerber-parser_drill_test.js
@@ -2,18 +2,18 @@
 // test subset - parsing drill files
 'use strict'
 
-const expect = require('chai').expect
-const partial = require('lodash.partial')
+var expect = require('chai').expect
+var partial = require('lodash.partial')
 
-const parser = require('../lib/gerber-parser')
+var parser = require('../lib/gerber-parser')
 
 describe('gerber parser with gerber files', function() {
-  let p
-  const pFactory = partial(parser, {filetype: 'drill'})
+  var p
+  var pFactory = partial(parser, {filetype: 'drill'})
 
   // convenience function to expect an array of results
-  const expectResults = function(expected, done) {
-    const handleData = function(res) {
+  var expectResults = function(expected, done) {
+    var handleData = function(res) {
       expect(res).to.eql(expected.shift())
       if (!expected.length) {
         return done()
@@ -36,13 +36,13 @@ describe('gerber parser with gerber files', function() {
   describe('comments', function() {
     it('should do nothing with most comments', function(done) {
       p.once('data', function(d) {
-        throw new Error(`should not have emitted: ${d}`)
+        throw new Error('should not have emitted: ' + d)
       })
       p.once('warning', function(w) {
-        throw new Error(`should not have warned: ${w.message}`)
+        throw new Error('should not have warned: ' + w.message)
       })
       p.once('error', function(e) {
-        throw new Error(`should not have errored: ${e.message}`)
+        throw new Error('should not have errored: ' + e.message)
       })
 
       p.write(';INCH\n')
@@ -77,7 +77,7 @@ describe('gerber parser with gerber files', function() {
       })
 
       it('should set backupUnits and backupNota', function(done) {
-        const expected = [
+        var expected = [
           {cmd: 'set', line: 1, key: 'backupNota', val: 'A'},
           {cmd: 'set', line: 1, key: 'backupUnits', val: 'mm'},
           {cmd: 'set', line: 2, key: 'backupNota', val: 'I'},
@@ -92,7 +92,7 @@ describe('gerber parser with gerber files', function() {
   })
 
   it('should call done with M00 and M30', function(done) {
-    const expected = [
+    var expected = [
       {cmd: 'done', line: 1},
       {cmd: 'done', line: 2}
     ]
@@ -103,7 +103,7 @@ describe('gerber parser with gerber files', function() {
   })
 
   it('should set notation with G90 and G91', function(done) {
-    const expected = [
+    var expected = [
       {cmd: 'set', line: 1, key: 'nota', val: 'A'},
       {cmd: 'set', line: 2, key: 'nota', val: 'I'}
     ]
@@ -115,7 +115,7 @@ describe('gerber parser with gerber files', function() {
 
   describe('parsing unit set', function() {
     it('should set units and suppression with INCH / METRIC', function(done) {
-      const expected = [
+      var expected = [
         {cmd: 'set', line: 1, key: 'units', val: 'in'},
         {cmd: 'set', line: 2, key: 'units', val: 'mm'},
         {cmd: 'set', line: 3, key: 'units', val: 'in'},
@@ -130,7 +130,7 @@ describe('gerber parser with gerber files', function() {
     })
 
     it('should set units with M71 and M72', function(done) {
-      const expected = [
+      var expected = [
         {cmd: 'set', line: 1, key: 'units', val: 'in'},
         {cmd: 'set', line: 2, key: 'units', val: 'mm'}
       ]
@@ -196,11 +196,11 @@ describe('gerber parser with gerber files', function() {
 
   describe('parsing tool definitions', function() {
     it('should send a tool command', function(done) {
-      const expectedTools = [
+      var expectedTools = [
         {shape: 'circle', val: [0.015], hole: []},
         {shape: 'circle', val: [0.142], hole: []}
       ]
-      const expected = [
+      var expected = [
         {cmd: 'tool', line: 1, key: '1', val: expectedTools[0]},
         {cmd: 'tool', line: 2, key: '13', val: expectedTools[1]}
       ]
@@ -211,10 +211,10 @@ describe('gerber parser with gerber files', function() {
     })
 
     it('should ignore feedrate and spindle speed', function(done) {
-      const expectedTools = [
+      var expectedTools = [
         {shape: 'circle', val: [0.01], hole: []}
       ]
-      const expected = [
+      var expected = [
         {cmd: 'tool', line: 1, key: '1', val: expectedTools[0]}
       ]
 
@@ -223,10 +223,10 @@ describe('gerber parser with gerber files', function() {
     })
 
     it('should ignore leading zeros in tool name', function(done) {
-      const expectedTools = [
+      var expectedTools = [
         {shape: 'circle', val: [0.015], hole: []}
       ]
-      const expected = [
+      var expected = [
         {cmd: 'tool', line: 1, key: '23', val: expectedTools[0]}
       ]
 
@@ -236,7 +236,7 @@ describe('gerber parser with gerber files', function() {
   })
 
   it('should set the tool with a tool number', function(done) {
-    const expected = [
+    var expected = [
       {cmd: 'set', line: 1, key: 'tool', val: '1'},
       {cmd: 'set', line: 2, key: 'tool', val: '14'},
       {cmd: 'set', line: 3, key: 'tool', val: '5'},
@@ -257,7 +257,7 @@ describe('gerber parser with gerber files', function() {
       p.format.places = [2, 4]
       p.format.zero = 'T'
 
-      const expected = [
+      var expected = [
         {cmd: 'op', line: 1, key: 'flash', val: {x: 0.16, y: 1.58}},
         {cmd: 'op', line: 2, key: 'flash', val: {x: -1.795, y: 1.08}}
       ]
@@ -271,7 +271,7 @@ describe('gerber parser with gerber files', function() {
       p.format.places = [2,4]
       p.format.zero = 'L'
 
-      const expected = [
+      var expected = [
         {cmd: 'op', line: 1, key: 'flash', val: {x: 0.005, y: 1.55}},
         {cmd: 'op', line: 2, key: 'flash', val: {x: 1.685, y: -0.33}}
       ]
@@ -282,7 +282,7 @@ describe('gerber parser with gerber files', function() {
     })
 
     it('should parse with the places format', function(done) {
-      const expected = [
+      var expected = [
         {cmd: 'op', line: 1, key: 'flash', val: {x: .755, y: 1.4}},
         {cmd: 'op', line: 2, key: 'flash', val: {x: 7.55, y: 0.014}},
         {cmd: 'op', line: 3, key: 'flash', val: {x: 8, y: 1.24}},
@@ -310,7 +310,7 @@ describe('gerber parser with gerber files', function() {
       p.format.zero = 'L'
       p.format.places = [2,4]
 
-      const expected = [
+      var expected = [
         {cmd: 'op', line: 1, key: 'flash', val: {x: 0.755, y: 1.4}}
       ]
 
@@ -322,7 +322,7 @@ describe('gerber parser with gerber files', function() {
       p.format.zero = 'T'
       p.format.places = [2,4]
 
-      const expected = [
+      var expected = [
         {cmd: 'set', line: 1, key: 'tool', val: '1'},
         {cmd: 'op', line: 1, key: 'flash', val: {x: 1, y: 1}},
         {cmd: 'set', line: 2, key: 'tool', val: '1'},

--- a/test/gerber-parser_gerber_test.js
+++ b/test/gerber-parser_gerber_test.js
@@ -2,18 +2,18 @@
 // test subset - parsing gerber files
 'use strict'
 
-const expect = require('chai').expect
-const partial = require('lodash.partial')
+var expect = require('chai').expect
+var partial = require('lodash.partial')
 
-const parser = require('../lib/gerber-parser')
+var parser = require('../lib/gerber-parser')
 
 describe('gerber parser with gerber files', function() {
-  let p
-  const pFactory = partial(parser, {filetype: 'gerber'})
+  var p
+  var pFactory = partial(parser, {filetype: 'gerber'})
 
   // convenience function to expect an array of results
-  const expectResults = function(expected, done) {
-    const handleData = function(res) {
+  var expectResults = function(expected, done) {
+    var handleData = function(res) {
       expect(res).to.eql(expected.shift())
       if (!expected.length) {
         return done()
@@ -107,7 +107,7 @@ describe('gerber parser with gerber files', function() {
   })
 
   it('should end the file with a M02', function(done) {
-    const expected = [{cmd: 'done', line: 0}]
+    var expected = [{cmd: 'done', line: 0}]
 
     expectResults(expected, done)
     p.write('M02*\n')
@@ -115,7 +115,7 @@ describe('gerber parser with gerber files', function() {
 
   describe('general set commands (G-codes)', function() {
     it('should set region mode on/off with G36/7', function(done) {
-      const expected = [
+      var expected = [
         {cmd: 'set', key: 'region', val: true, line: 0},
         {cmd: 'set', key: 'region', val: false, line: 1}
       ]
@@ -125,7 +125,7 @@ describe('gerber parser with gerber files', function() {
     })
 
     it('should set interpolation mode with G01/2/3', function(done) {
-      const expected = [
+      var expected = [
         {cmd: 'set', key: 'mode', val: 'i', line: 0},
         {cmd: 'set', key: 'mode', val: 'cw', line: 1},
         {cmd: 'set', key: 'mode', val: 'ccw', line: 2},
@@ -140,7 +140,7 @@ describe('gerber parser with gerber files', function() {
     })
 
     it('should set the arc mode with G74/5', function(done) {
-      const expected = [
+      var expected = [
         {cmd: 'set', key: 'arc', val: 's', line: 0},
         {cmd: 'set', key: 'arc', val: 'm', line: 1}
       ]
@@ -152,7 +152,7 @@ describe('gerber parser with gerber files', function() {
 
   describe('unit set commands (MO parameter)', function() {
     it('should set units with %MOIN*% and %MOMM*%', function(done) {
-      const expected = [
+      var expected = [
         {cmd: 'set', key: 'units', val: 'in', line: 0},
         {cmd: 'set', key: 'units', val: 'mm', line: 1}
       ]
@@ -163,7 +163,7 @@ describe('gerber parser with gerber files', function() {
     })
 
     it('should set backup units with G70/1', function(done) {
-      const expected = [
+      var expected = [
         {cmd: 'set', key: 'backupUnits', val: 'in', line: 0},
         {cmd: 'set', key: 'backupUnits', val: 'mm', line: 1}
       ]
@@ -175,7 +175,7 @@ describe('gerber parser with gerber files', function() {
 
   describe('format block', function() {
     it('should parse zero suppression', function() {
-      let format = '%FSLAX34Y34*%'
+      var format = '%FSLAX34Y34*%'
       p.write(format)
       expect(p.format.zero).to.equal('L')
 
@@ -196,7 +196,7 @@ describe('gerber parser with gerber files', function() {
     })
 
     it('should parse places format', function() {
-      let format = '%FSLAX34Y34*%'
+      var format = '%FSLAX34Y34*%'
       p.write(format)
       expect(p.format.places).to.eql([3, 4])
 
@@ -207,7 +207,7 @@ describe('gerber parser with gerber files', function() {
     })
 
     it('should not override user-set places or suppression', function() {
-      const format = '%FSLAX34Y34*%'
+      var format = '%FSLAX34Y34*%'
       p.format.zero = 'T'
       p.format.places = [7, 7]
       p.write(format)
@@ -216,11 +216,11 @@ describe('gerber parser with gerber files', function() {
     })
 
     it('should set notation and epsilon', function(done) {
-      const format1 = '%FSLAX34Y34*%\n'
-      const format2 = '%FSLIX77Y77*%\n'
+      var format1 = '%FSLAX34Y34*%\n'
+      var format2 = '%FSLIX77Y77*%\n'
       // ensure it parses if suppression is missing
-      const format3 = '%FSAX66Y66*%\n'
-      const expected = [
+      var format3 = '%FSAX66Y66*%\n'
+      var expected = [
         {cmd: 'set', line: 0, key: 'nota', val: 'A'},
         {cmd: 'set', line: 0, key: 'epsilon', val: 1.5 * Math.pow(10, -4)},
         {cmd: 'set', line: 1, key: 'nota', val: 'I'},
@@ -239,7 +239,7 @@ describe('gerber parser with gerber files', function() {
     })
 
     it('should warn and set leading if suppression missing', function(done) {
-      const format = '%FSAX34Y34*%\n'
+      var format = '%FSAX34Y34*%\n'
       p.once('warning', function(w) {
         expect(w.line).to.equal(0)
         expect(w.message).to.match(/suppression missing/)
@@ -253,7 +253,7 @@ describe('gerber parser with gerber files', function() {
 
   describe('new level commands (SR/LP parameters)', function() {
     it('should parse a new level polarity', function(done) {
-      const expected = [
+      var expected = [
         {cmd: 'level', line: 0, key: 'polarity', val: 'D'},
         {cmd: 'level', line: 1, key: 'polarity', val: 'C'}
       ]
@@ -263,7 +263,7 @@ describe('gerber parser with gerber files', function() {
     })
 
     it('should parse a new step-repeat level', function(done) {
-      const expected = [
+      var expected = [
         {
           cmd: 'level',
           line: 0,
@@ -299,7 +299,7 @@ describe('gerber parser with gerber files', function() {
     })
 
     it('should parse a tool change block', function(done) {
-      const expected = [
+      var expected = [
         {cmd: 'set', line: 0, key: 'tool', val: '10'},
         {cmd: 'set', line: 1, key: 'tool', val: '11'},
         {cmd: 'set', line: 2, key: 'tool', val: '12'}
@@ -312,12 +312,12 @@ describe('gerber parser with gerber files', function() {
     })
 
     it('should handle standard circles', function(done) {
-      const expectedTools = [
+      var expectedTools = [
         {shape: 'circle', val: [1], hole: []},
         {shape: 'circle', val: [1], hole: [0.1]},
         {shape: 'circle', val: [1], hole: [0.2, 0.3]}
       ]
-      const expected = [
+      var expected = [
         {cmd: 'tool', line: 0, key: '10', val: expectedTools[0]},
         {cmd: 'tool', line: 1, key: '11', val: expectedTools[1]},
         {cmd: 'tool', line: 2, key: '12', val: expectedTools[2]}
@@ -330,12 +330,12 @@ describe('gerber parser with gerber files', function() {
     })
 
     it('should handle standard rectangles/obrounds', function(done) {
-      const expectedTools = [
+      var expectedTools = [
         {shape: 'rect', val: [1, 2], hole: []},
         {shape: 'obround', val: [3, 4], hole: [0.1]},
         {shape: 'rect', val: [5, 6], hole: [0.2, 0.3]}
       ]
-      const expected = [
+      var expected = [
         {cmd: 'tool', line: 0, key: '10', val: expectedTools[0]},
         {cmd: 'tool', line: 1, key: '11', val: expectedTools[1]},
         {cmd: 'tool', line: 2, key: '12', val: expectedTools[2]}
@@ -348,13 +348,13 @@ describe('gerber parser with gerber files', function() {
     })
 
     it('should handle standard polygons', function(done) {
-      const expectedTools = [
+      var expectedTools = [
         {shape: 'poly', val: [1, 5, 0], hole: []},
         {shape: 'poly', val: [2, 6, 45], hole: []},
         {shape: 'poly', val: [3, 7, 0], hole: [0.1]},
         {shape: 'poly', val: [4, 8, 0], hole: [0.2, 0.3]}
       ]
-      const expected = [
+      var expected = [
         {cmd: 'tool', line: 0, key: '10', val: expectedTools[0]},
         {cmd: 'tool', line: 1, key: '11', val: expectedTools[1]},
         {cmd: 'tool', line: 2, key: '12', val: expectedTools[2]},
@@ -369,11 +369,11 @@ describe('gerber parser with gerber files', function() {
     })
 
     it('should handle aperture macro tools', function(done) {
-      const expectedTools = [
+      var expectedTools = [
         {shape: 'CIRC', val: [1, 0.5], hole: []},
         {shape: 'RECT', val: [], hole: []}
       ]
-      const expected = [
+      var expected = [
         {cmd: 'tool', line: 0, key: '10', val: expectedTools[0]},
         {cmd: 'tool', line: 1, key: '11', val: expectedTools[1]}
       ]
@@ -386,7 +386,7 @@ describe('gerber parser with gerber files', function() {
 
   describe('aperture macros', function() {
     it('should parse the name of the macro properly', function(done) {
-      const expected = [
+      var expected = [
         {cmd: 'macro', line: 0, key: 'NAME1', val: []},
         {cmd: 'macro', line: 1, key: 'CRAZY8', val: []}
       ]
@@ -397,13 +397,13 @@ describe('gerber parser with gerber files', function() {
     })
 
     describe('primitive blocks', function() {
-      const exp = 1
+      var exp = 1
 
       it('should parse comments', function(done) {
-        const expectedBlocks = [
+        var expectedBlocks = [
           {type: 'comment'}
         ]
-        const expected = [
+        var expected = [
           {cmd: 'macro', line: 1, key: 'NAME1', val: expectedBlocks}
         ]
 
@@ -413,10 +413,10 @@ describe('gerber parser with gerber files', function() {
       })
 
       it('should parse circle primitives', function(done) {
-        const expectedBlocks = [
-          {type: 'circle', exp, dia: 5, cx: 1, cy: 2}
+        var expectedBlocks = [
+          {type: 'circle', exp: exp, dia: 5, cx: 1, cy: 2}
         ]
-        const expected = [
+        var expected = [
           {cmd: 'macro', line: 1, key: 'CIRC1', val: expectedBlocks}
         ]
 
@@ -426,11 +426,11 @@ describe('gerber parser with gerber files', function() {
       })
 
       it('should parse vector primitives', function(done) {
-        const expectedBlocks = [
-          {type: 'vect', exp, width: 2, x1: 3, y1: 4, x2: 5, y2: 6, rot: 7},
-          {type: 'vect', exp, width: 2, x1: 3, y1: 4, x2: 5, y2: 6, rot: 7}
+        var expectedBlocks = [
+          {type: 'vect', exp: exp, width: 2, x1: 3, y1: 4, x2: 5, y2: 6, rot: 7},
+          {type: 'vect', exp: exp, width: 2, x1: 3, y1: 4, x2: 5, y2: 6, rot: 7}
         ]
-        const expected = [
+        var expected = [
           {cmd: 'macro', line: 2, key: 'VECT1', val: expectedBlocks}
         ]
 
@@ -452,10 +452,10 @@ describe('gerber parser with gerber files', function() {
       })
 
       it('should parse rectangle primitives', function(done) {
-        const expectedBlocks = [
-          {type: 'rect', exp, width: 2, height: 3, cx: 4, cy: 5, rot: 6}
+        var expectedBlocks = [
+          {type: 'rect', exp: exp, width: 2, height: 3, cx: 4, cy: 5, rot: 6}
         ]
-        const expected = [
+        var expected = [
           {cmd: 'macro', line: 1, key: 'RECT1', val: expectedBlocks}
         ]
 
@@ -465,10 +465,10 @@ describe('gerber parser with gerber files', function() {
       })
 
       it('should parse a lower left rectangle primitive', function(done) {
-        const expectedBlocks = [
-          {type: 'rectLL', exp, width: 2, height: 3, x: 4, y: 5, rot: 6}
+        var expectedBlocks = [
+          {type: 'rectLL', exp: exp, width: 2, height: 3, x: 4, y: 5, rot: 6}
         ]
-        const expected = [
+        var expected = [
           {cmd: 'macro', line: 1, key: 'RECTLL1', val: expectedBlocks}
         ]
 
@@ -489,10 +489,10 @@ describe('gerber parser with gerber files', function() {
       })
 
       it('should parse an outline polygon primitive', function(done) {
-        const expectedShapes = [
-          {type: 'outline', exp, points: [3, 4, 5, 6, 7, 8], rot: 9}
+        var expectedShapes = [
+          {type: 'outline', exp: exp, points: [3, 4, 5, 6, 7, 8], rot: 9}
         ]
-        const expected = [
+        var expected = [
           {cmd: 'macro', line: 1, key: 'OUT1', val: expectedShapes}
         ]
 
@@ -502,10 +502,10 @@ describe('gerber parser with gerber files', function() {
       })
 
       it('should parse a regular polygon primitive', function(done) {
-        const expectedShapes = [
-          {type: 'poly', exp, vertices: 3, cx: 4, cy: 5, dia: 6, rot: 7}
+        var expectedShapes = [
+          {type: 'poly', exp: exp, vertices: 3, cx: 4, cy: 5, dia: 6, rot: 7}
         ]
-        const expected = [
+        var expected = [
           {cmd: 'macro', line: 1, key: 'POLY1', val: expectedShapes}
         ]
 
@@ -515,17 +515,17 @@ describe('gerber parser with gerber files', function() {
       })
 
       it('should parse a moire primitive', function(done) {
-        const expectedShapes = [
+        var expectedShapes = [
           {
             type: 'moire',
-            exp,
+            exp: exp,
             cx: 1, cy: 2, dia: 3,
             ringThx: 4, ringGap: 5, maxRings: 6,
             crossThx: 7, crossLen: 8,
             rot: 9
           }
         ]
-        const expected = [
+        var expected = [
           {cmd: 'macro', line: 1, key: 'MOIRE1', val: expectedShapes}
         ]
 
@@ -535,10 +535,10 @@ describe('gerber parser with gerber files', function() {
       })
 
       it('should parse a thermal primitive', function(done) {
-        const expectedShapes = [
-          {type: 'thermal', exp, cx: 1, cy: 2, outerDia: 3, innerDia: 4, gap: 5, rot: 6}
+        var expectedShapes = [
+          {type: 'thermal', exp: exp, cx: 1, cy: 2, outerDia: 3, innerDia: 4, gap: 5, rot: 6}
         ]
-        const expected = [
+        var expected = [
           {cmd: 'macro', line: 1, key: 'THERMAL1', val: expectedShapes}
         ]
 
@@ -560,29 +560,29 @@ describe('gerber parser with gerber files', function() {
     })
 
     describe('variable set blocks', function() {
-      let mods
+      var mods
       beforeEach(function() {
         mods = {$1: 42}
       })
 
-      const expectExprResults = function(expected, done) {
+      var expectExprResults = function(expected, done) {
         p.once('data', function(res) {
           expect(res.cmd).to.equal('macro')
           expect(res.key).to.equal('MODS1')
 
-          for (const v of res.val) {
-            const newMods = v.set(mods)
+          res.val.forEach(function(v) {
+            var newMods = v.set(mods)
             expect(v.type).to.equal('variable')
             expect(newMods).to.eql(expected.shift())
             expect(newMods).to.not.equal(mods)
-          }
+          })
 
           done()
         })
       }
 
       it('should return function that takes / returns mods', function(done) {
-        const expected = [
+        var expected = [
           {$1: 42, $2: 1}
         ]
 
@@ -592,7 +592,7 @@ describe('gerber parser with gerber files', function() {
       })
 
       it('should parse addition', function(done) {
-        const expected = [
+        var expected = [
           {$1: 42, $2: 3},
           {$1: 42, $2: 56}
         ]
@@ -604,7 +604,7 @@ describe('gerber parser with gerber files', function() {
       })
 
       it('should parse subtraction', function(done) {
-        const expected = [
+        var expected = [
           {$1: 42, $2: 3},
           {$1: 42, $2: 21}
         ]
@@ -616,7 +616,7 @@ describe('gerber parser with gerber files', function() {
       })
 
       it('should parse multiplication with x and X', function(done) {
-        const expected = [
+        var expected = [
           {$1: 42, $2: 21},
           {$1: 42, $2: 6}
         ]
@@ -638,7 +638,7 @@ describe('gerber parser with gerber files', function() {
       })
 
       it('should parse division with /', function(done) {
-        const expected = [
+        var expected = [
           {$1: 42, $2: 4},
           {$1: 42, $2: 21}
         ]
@@ -650,7 +650,7 @@ describe('gerber parser with gerber files', function() {
       })
 
       it('should handle expressions with parentheses', function(done) {
-        const expected = [
+        var expected = [
           {$1: 42, $2: 3}
         ]
 
@@ -678,7 +678,7 @@ describe('gerber parser with gerber files', function() {
     })
 
     it('should parse an interpolation command', function(done) {
-      const expected = [
+      var expected = [
         {cmd: 'op', line: 0, key: 'int', val: {x: 0.1, y: 0.2, i: 0.3, j: 0.4}},
         {cmd: 'op', line: 1, key: 'int', val: {x: 0.11, y: 0}},
         {cmd: 'op', line: 2, key: 'int', val: {x: 0.22}},
@@ -695,7 +695,7 @@ describe('gerber parser with gerber files', function() {
     })
 
     it('should parse a move command', function(done) {
-      const expected = [
+      var expected = [
         {cmd: 'op', line: 0, key: 'move', val: {x: 0.3, y: 0.001}},
         {cmd: 'op', line: 1, key: 'move', val: {x: -0.1}},
         {cmd: 'op', line: 2, key: 'move', val: {}}
@@ -708,7 +708,7 @@ describe('gerber parser with gerber files', function() {
     })
 
     it('should parse a flash command', function(done) {
-      const expected = [
+      var expected = [
         {cmd: 'op', line: 0, key: 'flash', val: {x: 0.3, y: 0.001}},
         {cmd: 'op', line: 1, key: 'flash', val: {x: -0.1}},
         {cmd: 'op', line: 2, key: 'flash', val: {}}
@@ -721,7 +721,7 @@ describe('gerber parser with gerber files', function() {
     })
 
     it('should send "last" operation if op code is missing', function(done) {
-      const expected = [
+      var expected = [
         {cmd: 'op', line: 0, key: 'last', val: {x: 0.3, y: 0.001}},
         {cmd: 'op', line: 1, key: 'last', val: {x: -0.1}}
       ]
@@ -732,7 +732,7 @@ describe('gerber parser with gerber files', function() {
     })
 
     it('should interpolate with inline mode set', function(done) {
-      const expected = [
+      var expected = [
         {cmd: 'set', line: 0, key: 'mode', val: 'i'},
         {cmd: 'op', line: 0, key: 'int', val: {x: 0.001, y: 0.001}},
         {cmd: 'set', line: 1, key: 'mode', val: 'cw'},

--- a/test/gerber-parser_test.js
+++ b/test/gerber-parser_test.js
@@ -1,41 +1,43 @@
 // test suite for the top level gerber parser class
 'use strict'
 
-const Transform = require('stream').Transform
-const expect = require('chai').expect
-const parser = require('../lib/gerber-parser')
+var Transform = require('stream').Transform
+var expect = require('chai').expect
+var repeat = require('lodash.repeat')
+
+var parser = require('../lib/gerber-parser')
 
 describe('gerber parser', function() {
   describe('factory and options', function() {
     it('should return a transform stream', function() {
-      const p = parser()
+      var p = parser()
       expect(p).to.be.an.instanceOf(Transform)
     })
 
     it('should allow setting the zero suppression', function() {
-      let p = parser({zero: 'L'})
+      var p = parser({zero: 'L'})
       expect(p.format.zero).to.equal('L')
       p = parser({zero: 'T'})
       expect(p.format.zero).to.equal('T')
     })
 
     it('should allow setting the number places format', function() {
-      let p = parser({places: [1, 4]})
+      var p = parser({places: [1, 4]})
       expect(p.format.places).to.eql([1, 4])
       p = parser({places: [3, 4]})
       expect(p.format.places).to.eql([3, 4])
     })
 
     it('should allow setting the filetype', function() {
-      let p = parser({filetype: 'gerber'})
+      var p = parser({filetype: 'gerber'})
       expect(p.format.filetype).to.equal('gerber')
       p = parser({filetype: 'drill'})
       expect(p.format.filetype).to.equal('drill')
     })
 
     it('should throw with bad options to the contructor', function() {
-      let p
-      let badOpts = {places: 'string'}
+      var p
+      var badOpts = {places: 'string'}
       expect(function() {p = parser(badOpts)}).to.throw(/places/)
       badOpts = {places: [1, 2, 3]}
       expect(function() {p = parser(badOpts)}).to.throw(/places/)
@@ -52,7 +54,7 @@ describe('gerber parser', function() {
   })
 
   describe('reading files', function() {
-    let p
+    var p
     beforeEach(function() {
       p = parser()
     })
@@ -96,7 +98,7 @@ describe('gerber parser', function() {
           expect(err.message).to.match(/determine filetype/)
           done()
         })
-        p.write(';'.repeat(10000000))
+        p.write(repeat(';', 10000000))
       })
 
       it('should stash chunks if it cannot make a determination', function() {
@@ -108,7 +110,7 @@ describe('gerber parser', function() {
     })
 
     it("should know what line it's on", function() {
-      p.write('*\n'.repeat(5))
+      p.write(repeat('*\n', 5))
       expect(p.line).to.equal(5)
     })
   })

--- a/test/gerber-parser_test.js
+++ b/test/gerber-parser_test.js
@@ -1,7 +1,7 @@
 // test suite for the top level gerber parser class
 'use strict'
 
-var Transform = require('stream').Transform
+var Transform = require('readable-stream').Transform
 var expect = require('chai').expect
 var repeat = require('lodash.repeat')
 

--- a/test/get-next-block_test.js
+++ b/test/get-next-block_test.js
@@ -1,31 +1,31 @@
 // tests for function that gets the next block from a chunk
 'use strict'
 
-const expect = require('chai').expect
-const partial = require('lodash.partial')
-const getNextBlock = require('../lib/get-next-block')
+var expect = require('chai').expect
+var partial = require('lodash.partial')
+var getNextBlock = require('../lib/get-next-block')
 
 describe('get next block', function() {
   it ('should throw with a bad filetype', function() {
-    const bad = function() {getNextBlock('foo', '', 0)}
+    var bad = function() {getNextBlock('foo', '', 0)}
     expect(bad).to.throw(/filetype/)
   })
 
   describe('from gerber files', function() {
-    const getNext = partial(getNextBlock, 'gerber')
+    var getNext = partial(getNextBlock, 'gerber')
 
     it('should split at *', function() {
-      const chunk = 'M02*'
-      const result = getNext(chunk, 0)
+      var chunk = 'M02*'
+      var result = getNext(chunk, 0)
 
       expect(result.block).to.equal('M02')
     })
 
     it('should return characters read', function() {
-      const chunk = 'G01*G02*G03*'
-      const res1 = getNext(chunk, 0)
-      const res2 = getNext(chunk, 4)
-      const res3 = getNext(chunk, 8)
+      var chunk = 'G01*G02*G03*'
+      var res1 = getNext(chunk, 0)
+      var res2 = getNext(chunk, 4)
+      var res3 = getNext(chunk, 8)
 
       expect(res1.block).to.equal('G01')
       expect(res2.block).to.equal('G02')
@@ -36,10 +36,10 @@ describe('get next block', function() {
     })
 
     it('should return newlines read', function() {
-      const chunk = 'G01*\nG02*\nG03*\n'
-      const res1 = getNext(chunk, 0)
-      const res2 = getNext(chunk, 4)
-      const res3 = getNext(chunk, 9)
+      var chunk = 'G01*\nG02*\nG03*\n'
+      var res1 = getNext(chunk, 0)
+      var res2 = getNext(chunk, 4)
+      var res3 = getNext(chunk, 9)
 
       expect(res1.block).to.equal('G01')
       expect(res2.block).to.equal('G02')
@@ -53,9 +53,9 @@ describe('get next block', function() {
     })
 
     it('should skip the end percent of a param', function() {
-      const chunk = '%FSLAX24Y24*%\n%MOIN*%\n'
-      const res1 = getNext(chunk, 0)
-      const res2 = getNext(chunk, 13)
+      var chunk = '%FSLAX24Y24*%\n%MOIN*%\n'
+      var res1 = getNext(chunk, 0)
+      var res2 = getNext(chunk, 13)
 
       expect(res1.block).to.equal('%FSLAX24Y24')
       expect(res2.block).to.equal('%MOIN')
@@ -67,14 +67,14 @@ describe('get next block', function() {
   })
 
   describe('from drill files', function() {
-    const getNext = partial(getNextBlock, 'drill')
+    var getNext = partial(getNextBlock, 'drill')
 
     it('should split at newlines', function() {
-      const chunk = 'G90\nG05\nM72\nM30\n'
-      const res1 = getNext(chunk, 0)
-      const res2 = getNext(chunk, 4)
-      const res3 = getNext(chunk, 8)
-      const res4 = getNext(chunk, 12)
+      var chunk = 'G90\nG05\nM72\nM30\n'
+      var res1 = getNext(chunk, 0)
+      var res2 = getNext(chunk, 4)
+      var res3 = getNext(chunk, 8)
+      var res4 = getNext(chunk, 12)
 
       expect(res1.block).to.equal('G90')
       expect(res2.block).to.equal('G05')

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,3 @@
 --reporter spec
 --ui bdd
---harmony_shipping
 --timeout 500ms

--- a/test/normalize-coord_test.js
+++ b/test/normalize-coord_test.js
@@ -2,8 +2,8 @@
 // input: a coordinate string from a gerber file, output: a number
 'use strict'
 
-const expect = require('chai').expect
-const normalize = require('../lib/normalize-coord')
+var expect = require('chai').expect
+var normalize = require('../lib/normalize-coord')
 
 describe('normalize coordinate', function() {
   it('should return NaN for bad input', function() {

--- a/test/parse-coord_test.js
+++ b/test/parse-coord_test.js
@@ -1,11 +1,11 @@
 // test suite for coordinate parser function
 'use strict'
 
-const expect = require('chai').expect
-const parseCoord = require('../lib/parse-coord')
+var expect = require('chai').expect
+var parseCoord = require('../lib/parse-coord')
 
 // svg coordinate FACTOR
-const FORMAT = {places: [2, 3], zeros: null}
+var FORMAT = {places: [2, 3], zeros: null}
 
 describe('coordinate parser', function() {
   it('should throw if passed an incorrect format', function() {


### PR DESCRIPTION
ES6 is fun and nice, but given that I don't really need to be using it, publishing ES6 to npm seems undesirable, and transpiling ES6 to ES5 for maximum support is a pain, it seems that just writing in ES5 is the best option.

This PR removes ES6 features and adds tooling to run CI testing all the way back to node 0.10.
