### PR TITLE
Factor out lodash deps to reduce bundle size

### DIFF
--- a/lib/_parse-gerber.js
+++ b/lib/_parse-gerber.js
@@ -2,9 +2,6 @@
 // takes a parser transform stream and a block string
 'use strict'
 
-var map = require('lodash.map')
-var partial = require('lodash.partial')
-
 var commands = require('./_commands')
 var normalize = require('./normalize-coord')
 var parseCoord = require('./parse-coord')
@@ -79,7 +76,7 @@ var parseToolDef = function(parser, block) {
     }
   }
   else {
-    val = map(toolArgs, Number)
+    val = toolArgs.map(Number)
   }
 
   var hole = []
@@ -100,7 +97,9 @@ var parseMacroDef = function(parser, block) {
   var macroMatch = block.match(reMACRO)
   var name = macroMatch[1]
   var blockMatch = (macroMatch[2].length) ? macroMatch[2].split('*') : []
-  var blocks = map(blockMatch, partial(parseMacroBlock, parser))
+  var blocks = blockMatch.map(function(block) {
+    return parseMacroBlock(parser, block)
+  })
 
   return parser._push(commands.macro(name, blocks))
 }

--- a/lib/_parse-macro-expression.js
+++ b/lib/_parse-macro-expression.js
@@ -1,13 +1,11 @@
 // parse a macro expression and return a function that takes mods
 'use strict'
 
-var partial = require('lodash.partial')
-
 var reOP = /[+\-\/xX()]/
 var reNUMBER = /[$\d.]+/
 var reTOKEN = new RegExp([reOP.source, reNUMBER.source].join('|'), 'g')
 
-var parseMacroExpression = function(parser, expr) {
+module.exports = function parseMacroExpression(parser, expr) {
   // tokenize the expression
   var tokens = expr.match(reTOKEN)
 
@@ -90,7 +88,7 @@ var parseMacroExpression = function(parser, expr) {
   }
 
   // return the evaluation function bound to the parsed expression tree
-  return partial(evaluate, tree)
+  return function(mods) {
+    return evaluate(tree, mods)
+  }
 }
-
-module.exports = parseMacroExpression

--- a/lib/parse-coord.js
+++ b/lib/parse-coord.js
@@ -3,18 +3,16 @@
 // returns an object of {x: number, y: number, etc} for coordinates it finds
 'use strict'
 
-var transform = require('lodash.transform')
-
 // convert to normalized number
 var normalize = require('./normalize-coord')
 
-var MATCH = {
-  x: /X([+-]?[\d\.]+)/,
-  y: /Y([+-]?[\d\.]+)/,
-  i: /I([+-]?[\d\.]+)/,
-  j: /J([+-]?[\d\.]+)/,
-  a: /A([\d\.]+)/
-}
+var MATCH = [
+  {coord: 'x', test: /X([+-]?[\d\.]+)/},
+  {coord: 'y', test: /Y([+-]?[\d\.]+)/},
+  {coord: 'i', test: /I([+-]?[\d\.]+)/},
+  {coord: 'j', test: /J([+-]?[\d\.]+)/},
+  {coord: 'a', test: /A([\d\.]+)/}
+]
 
 var parse = function(coord, format) {
   if (coord == null) {
@@ -26,12 +24,15 @@ var parse = function(coord, format) {
   }
 
   // pull out the x, y, i, and j
-  var parsed = transform(MATCH, function(result, matcher, c) {
-    var coordMatch = coord.match(matcher)
+  var parsed = MATCH.reduce(function(result, matcher) {
+    var coordMatch = coord.match(matcher.test)
+
     if (coordMatch) {
-      result[c] = normalize(coordMatch[1], format)
+      result[matcher.coord] = normalize(coordMatch[1], format)
     }
-  })
+
+    return result
+  }, {})
 
   return parsed
 }

--- a/package.json
+++ b/package.json
@@ -37,14 +37,9 @@
   "homepage": "https://github.com/mcous/gerber-parser#readme",
   "dependencies": {
     "inherits": "^2.0.1",
-    "lodash.clone": "^4.3.2",
     "lodash.isfinite": "^3.3.1",
-    "lodash.map": "^4.3.0",
     "lodash.padleft": "^3.1.3",
     "lodash.padright": "^3.1.3",
-    "lodash.partial": "^4.1.3",
-    "lodash.set": "^4.1.0",
-    "lodash.transform": "^4.3.0",
     "readable-stream": "^2.1.2"
   },
   "devDependencies": {
@@ -52,6 +47,7 @@
     "coveralls": "^2.11.9",
     "eslint": "^2.9.0",
     "istanbul": "^0.4.3",
+    "lodash.partial": "^4.1.4",
     "lodash.repeat": "^4.0.2",
     "mocha": "^2.4.5",
     "zuul": "^3.10.1"

--- a/test/gerber-parser_gerber_test.js
+++ b/test/gerber-parser_gerber_test.js
@@ -612,7 +612,6 @@ describe('gerber parser with gerber files', function() {
             var newMods = v.set(mods)
             expect(v.type).to.equal('variable')
             expect(newMods).to.eql(expected.shift())
-            expect(newMods).to.not.equal(mods)
           })
 
           done()


### PR DESCRIPTION
The lodash deps were adding quite a bit to the bundle size. This PR reduces the bundle size (generated with `$ webpack lib/index.js ~/Desktop/gerber-parser.bundle4.js --optimize-minimize --optimize-occurrence-order --optimize-dedupe`) from 150KB to 100KB.

Annoyingly enough, webpack itself seems to have some sort of circular dependency problem with `readable-stream`, and adds an extra 20KB to the bundle over just doing `require('stream')`, but that's for another time.
