### PR TITLE
Remove uses of non-existent falsey assertion

### DIFF
--- a/test/gerber-parser_drill_test.js
+++ b/test/gerber-parser_drill_test.js
@@ -69,7 +69,7 @@ describe('gerber parser with gerber files', function() {
           p = pFactory()
           p.write(';FORMAT={-:-/ absolute / inch / decimal}\n')
           expect(p.format.zero).to.equal('D')
-          expect(p.format.places).to.be.falsey
+          expect(p.format.places).to.not.be.ok
 
           p = pFactory()
           p.write(';FORMAT={3:3/ absolute / metric / keep zeros}\n')

--- a/test/gerber-parser_test.js
+++ b/test/gerber-parser_test.js
@@ -55,13 +55,13 @@ describe('gerber parser', function() {
     it('should not throw with null/undefined options', function() {
       var p
       expect(function() {p = parser({places: null})}).to.not.throw()
-      expect(p.format.places).to.be.falsey
+      expect(p.format.places).to.not.be.ok
 
       expect(function() {p = parser({filetype: undefined})}).to.not.throw()
-      expect(p.format.filetype).to.be.falsey
+      expect(p.format.filetype).to.not.be.ok
 
       expect(function() {p = parser({zero: null})}).to.not.throw()
-      expect(p.format.zero).to.be.falsey
+      expect(p.format.zero).to.be.not.be.ok
     })
   })
 


### PR DESCRIPTION
Was just trying to use this style on a pcb-stackup test and then wondered where I picked up this bad habit :)

```
> var expect = require('chai').expect
> expect(true).to.be.falsey
undefined
> expect(true).to.be.falsy
undefined
> expect(true).to.not.be.ok
AssertionError: expected true to be falsy
```
