### PR TITLE
Modified regex for macro names to reflect Gerber spec

### DIFF
--- a/lib/_parse-gerber.js
+++ b/lib/_parse-gerber.js
@@ -28,8 +28,8 @@ var reUNITS = /^%MO(IN|MM)/
 var reFORMAT = /^%FS([LT]?)([AI]?)(.*)X([0-7])([0-7])Y\4\5/
 var rePOLARITY = /^%LP([CD])/
 var reSTEP_REP = /^%SR(?:X(\d+)Y(\d+)I([\d.]+)J([\d.]+))?/
-var reTOOL_DEF = /^%ADD0*(\d{2,})([A-Za-z_]\w*)(?:,((?:X?[\d.]+)*))?/
-var reMACRO = /^%AM([A-Za-z_]\w*)\*?(.*)/
+var reTOOL_DEF = /^%ADD0*(\d{2,})([A-Za-z_\$][\w\-\.]*)(?:,((?:X?[\d.]+)*))?/
+var reMACRO = /^%AM([A-Za-z_\$][\w\-\.]*)\*?(.*)/
 
 var parseToolDef = function(parser, block) {
   var format = {places: parser.format.places}
@@ -96,6 +96,9 @@ var parseToolDef = function(parser, block) {
 var parseMacroDef = function(parser, block) {
   var macroMatch = block.match(reMACRO)
   var name = macroMatch[1]
+  if (name.match(/\-/)) {
+    parser._warn('hyphens in macro name are illegal: ' + name )
+  }
   var blockMatch = (macroMatch[2].length) ? macroMatch[2].split('*') : []
   var blocks = blockMatch.map(function(block) {
     return parseMacroBlock(parser, block)

--- a/test/gerber-parser_gerber_test.js
+++ b/test/gerber-parser_gerber_test.js
@@ -425,12 +425,28 @@ describe('gerber parser with gerber files', function() {
     it('should parse the name of the macro properly', function(done) {
       var expected = [
         {type: 'macro', line: 0, name: 'NAME1', blocks: []},
-        {type: 'macro', line: 1, name: 'CRAZY8', blocks: []}
+        {type: 'macro', line: 1, name: 'CRAZY8', blocks: []},
+        {type: 'macro', line: 2, name: 'NAME-1', blocks: []},
+        {type: 'macro', line: 3, name: 'Name1.0', blocks: []},
+        {type: 'macro', line: 4, name: '$Name1', blocks: []}
       ]
 
       expectResults(expected, done)
       p.write('%AMNAME1*%\n')
       p.write('%AMCRAZY8*%\n')
+      p.write('%AMNAME-1*%\n')
+      p.write('%AMName1.0*%\n')
+      p.write('%AM$Name1*%\n')
+    })
+
+    it('should warn that hyphens in macro names are invalid', function(done) {
+      p.once('warning', function(w) {
+        expect(w.line).to.equal(0)
+        expect(w.message).to.match(/hyphen/)
+        done()
+      })
+
+      p.write('%AMNAME-1*%\n')
     })
 
     describe('primitive blocks', function() {


### PR DESCRIPTION
According to the [Gerber spec](https://www.ucamco.com/files/downloads/file/81/the_gerber_file_format_specification.pdf), page 54, the name format for macros is 

```
Name = [a-zA-Z_.$]{[a-zA-Z_.0-9]+}
```

The original regex used 

```
([A-Za-z_]\w*)
```

However, `\w` does not include the period character. 

In addition, I've added the hyphen character to support Upverter's incorrect macro names. ([Source](https://forum.upverter.com/t/incorrect-aperture-macro-name-format-in-gerber/22810)). 

The new macro snippet is

```
([A-Za-z_][\w\-\.]*)
```
