### PR TITLE
Update tools to better support development on Windows

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,6 @@
   "rules": {
     "indent": [2, 2, {"SwitchCase": 1}],
     "quotes": [2, "single", "avoid-escape"],
-    "linebreak-style": [2, "unix"],
     "semi": [2, "never"],
     "eqeqeq": [2, "allow-null"],
     "no-extend-native": 2,

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 coverage
+.nyc_output

--- a/.zuul.yml
+++ b/.zuul.yml
@@ -4,9 +4,7 @@ browsers:
     version: -1..latest
   - name: safari
     version: -1..latest
-  # TODO: put firefox back to latest once sauce has deployed updated selenium
-  # see: https://twitter.com/saucelabs/status/750741932075323392
   - name: firefox
-    version: -1..46
+    version: -1..latest
   - name: ie
     version: -1..latest

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # gerber parser
+
 [![npm](https://img.shields.io/npm/v/gerber-parser.svg?style=flat-square)](https://www.npmjs.com/package/gerber-parser)
 [![Travis](https://img.shields.io/travis/mcous/gerber-parser.svg?style=flat-square)](https://travis-ci.org/mcous/gerber-parser)
 [![Coveralls](https://img.shields.io/coveralls/mcous/gerber-parser.svg?style=flat-square)](https://coveralls.io/github/mcous/gerber-parser)
 [![David](https://img.shields.io/david/mcous/gerber-parser.svg?style=flat-square)](https://david-dm.org/mcous/gerber-parser)
 [![David](https://img.shields.io/david/dev/mcous/gerber-parser.svg?style=flat-square)](https://david-dm.org/mcous/gerber-parser#info=devDependencies)
-
-**Work in progress.**
 
 A printed circuit board Gerber and drill file parser. Implemented as a Node transform stream that takes a Gerber text stream and emits objects to be consumed by some sort of PCB plotter.
 
@@ -37,14 +36,16 @@ See [API.md](./API.md)
 
 ## developing and contributing
 
-Tests are written in [Mocha](http://mochajs.org/) and run in Node, [PhantomJS](http://phantomjs.org/), and a variety of browsers with [Zuul](https://github.com/defunctzombie/zuul) and [Open Sauce](https://saucelabs.com/opensauce/). All PRs should be accompanied by unit tests, with ideally one feature / bugfix per PR. Code linting happens with [ESLint](http://eslint.org/) automatically post-test.
+Tests are written in [Mocha](http://mochajs.org/) and run in Node and a variety of browsers with [Zuul](https://github.com/defunctzombie/zuul) and [Open Sauce](https://saucelabs.com/opensauce/). All PRs should be accompanied by unit tests, with ideally one feature / bugfix per PR. Code is linted with [ESLint](http://eslint.org/).
 
 Code is deployed on tags via [TravisCI](https://travis-ci.org/) and code coverage is tracked with [Coveralls](https://coveralls.io/).
 
 ### build scripts
 
+* `$ npm test` - runs Node unit tests, calculates coverage, and runs the `lint` task
+* `$ npm run coverage` - print the coverage report of the last test run
+* `$ npm run coverage:html` - generate an html report for the last test run
 * `$ npm run lint` - lints code
-* `$ npm run test` - runs Node unit tests
 * `$ npm run test:watch` - runs unit tests and re-runs on changes
 * `$ npm run test:browser` - runs tests in a local browser
 * `$ npm run test:sauce` - runs tests in Sauce Labs on multiple browsers
@@ -54,3 +55,10 @@ Code is deployed on tags via [TravisCI](https://travis-ci.org/) and code coverag
   * Runs `npm test` and sends coverage report to Coveralls
   * If not a PR, runs browser tests in Sauce
   * Not designed to (and won't) run locally
+
+### deploying
+
+The module is published to npm automatically by Travis if the commit is tagged (and tests pass). To deploy:
+
+1. `$ npm version ...` - Use the npm version command to bump the version and tag the commit
+2. `$ git push --tags` - Push the tag to trigger a build

--- a/package.json
+++ b/package.json
@@ -4,15 +4,18 @@
   "description": "A PCB Gerber/drill-file parser implemented as a Node transform-stream",
   "main": "lib/index.js",
   "scripts": {
-    "lint": "eslint lib/*.js test/*.js",
-    "test": "istanbul cover --include-all-sources _mocha",
+    "lint": "eslint 'lib/*.js' 'test/*.js'",
+    "test": "nyc mocha",
     "posttest": "npm run lint",
     "test:watch": "mocha --reporter dot --timeout 500ms --watch",
     "test:browser": "zuul --local -- ./test/*_test.js",
     "test:sauce": "zuul -- ./test/*_test.js",
+    "coverage": "nyc report",
+    "coverage:html": "nyc report --reporter=html",
+    "coverage:ci": "nyc report --reporter=text-lcov | coveralls",
     "ci": "npm test && if [ \"${TEST_BROWSERS}\" = \"true\" ]; then npm run ci:browser; fi",
     "ci:browser": "if [ \"${TRAVIS_PULL_REQUEST}\" = \"false\" ]; then npm run test:sauce; fi",
-    "postci": "coveralls < ./coverage/lcov.info"
+    "postci": "npm run coverage:ci"
   },
   "repository": {
     "type": "git",
@@ -45,11 +48,11 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "coveralls": "^2.11.9",
-    "eslint": "^2.9.0",
-    "istanbul": "^0.4.3",
+    "eslint": "^2.13.1",
     "lodash.partial": "^4.1.4",
     "lodash.repeat": "^4.0.2",
     "mocha": "^2.4.5",
+    "nyc": "^7.1.0",
     "zuul": "^3.10.1"
   }
 }


### PR DESCRIPTION
1. Ditch the line-endings check in eslintrc
2. Use [nyc](https://github.com/istanbuljs/nyc) instead of [istanbul](https://github.com/gotwarlost/istanbul) for code coverage

Also included some chore work related to build and docs
- Re-add Firefox 47 as Sauce Labs seems to have fixed their bug
- Update the README (especially the contributing section) for accuracy
